### PR TITLE
replace call to __init__ with class to class constructor in Array.from_x

### DIFF
--- a/funlib/geometry/array.py
+++ b/funlib/geometry/array.py
@@ -7,7 +7,7 @@ class Array:
     @classmethod
     def from_world(cls, world_offset: Coordinate, world_shape: Coordinate, voxel_size: Coordinate):
         world_roi = Roi(world_offset, world_shape)
-        return cls.__init__(world_roi, voxel_size)
+        return cls(world_roi, voxel_size)
     
     @classmethod
     def from_pixels(cls, pixel_shape: Coordinate, voxel_size: Coordinate, world_offset: Coordinate | None = None, pixel_offset: Coordinate | None = None):
@@ -20,7 +20,7 @@ class Array:
         world_shape = Coordinate(pixel_shape) * Coordinate(voxel_size)
         
         world_roi = Roi(world_offset, world_shape)
-        return cls.__init__(world_roi, voxel_size)
+        return cls(world_roi, voxel_size)
 
 
     def __init__(self, world_roi: Roi, voxel_size: Coordinate):


### PR DESCRIPTION
cls.__init__ can only be called after the object has been created, so
the Array.from_x methods throw errors when trying to create new Rois.
